### PR TITLE
Fix the memory requirement for 7B when BLAS is enabled.

### DIFF
--- a/examples/redpajama/gptneox.cpp
+++ b/examples/redpajama/gptneox.cpp
@@ -96,7 +96,7 @@ static const std::map<e_model, size_t> & MEM_REQ_EVAL()
 {
     static std::map<e_model, size_t> _MEM_REQ_EVAL = {
         { MODEL_3B,   512ull * MiB },
-        { MODEL_7B,   768ull * MiB },
+        { MODEL_7B,   794ull * MiB },
         { MODEL_12B, 1024ull * MiB },
         { MODEL_20B, 1024ull * MiB },
     };


### PR DESCRIPTION
Found the new value by trail and error doing a binary search from the last value that worked (1024).

Fixes a segfault with message:

```
ggml_new_tensor_impl: not enough space in the context's memory pool (needed 830782032, available 805306368)
```